### PR TITLE
docs: Add Waitress for Windows & update README

### DIFF
--- a/jupy_agenda/README.md
+++ b/jupy_agenda/README.md
@@ -229,6 +229,35 @@ Esta aplicação é configurada para ser implantada usando um servidor WSGI como
     
     Dado que `run.py` está em `jupy_agenda/run.py`, e `app` é criado lá, para o CLI do Flask, `FLASK_APP=jupy_agenda.run` (quando executado da raiz do projeto) ou `FLASK_APP=run.py` (quando executado de dentro da pasta `jupy_agenda`) é o mais provável.
 
+### Alternativa para Windows: Waitress
+
+Se você estiver desenvolvendo ou deseja simular um ambiente de produção no Windows, pode encontrar problemas ao tentar usar o Gunicorn, pois ele possui dependências específicas do Unix (como o módulo `fcntl` que não está disponível no Windows).
+
+Uma excelente alternativa multiplataforma e de qualidade de produção é o servidor WSGI **Waitress**. Ele é puramente Python e funciona bem no Windows.
+
+**1. Instalação do Waitress:**
+   O Waitress já foi adicionado ao arquivo `requirements.txt` do projeto. Se por algum motivo não estiver instalado, você pode instalá-lo com:
+   ```bash
+   pip install waitress
+   ```
+
+**2. Configurando Variáveis de Ambiente:**
+   Assim como para o Gunicorn, certifique-se de que suas variáveis de ambiente de produção estão configuradas. Estas são as mesmas variáveis mencionadas anteriormente:
+   - `FLASK_ENV=production`
+   - `SECRET_KEY=sua_chave_secreta_super_segura`
+   - `SQLALCHEMY_DATABASE_URI=postgresql://user:pass@host:port/dbname` (ou outro banco de produção)
+   - Configurações de `MAIL_...` para envio de email.
+
+**3. Executando a Aplicação com Waitress:**
+   Use o seguinte comando no seu terminal (dentro do ambiente virtual ativado), a partir da raiz do projeto (a pasta que contém a pasta `jupy_agenda`):
+   ```bash
+   waitress-serve --host 0.0.0.0 --port 5000 "jupy_agenda.app:create_app()"
+   ```
+   - Você pode ajustar `--host` (e.g., `127.0.0.1` para apenas local) e `--port` (e.g., `8000`) conforme necessário.
+   - A string `"jupy_agenda.app:create_app()"` aponta para a fábrica da sua aplicação Flask localizada em `jupy_agenda/app/__init__.py`.
+
+O Waitress é uma opção robusta e fácil de usar para servir aplicações Flask em ambientes Windows onde Gunicorn não é uma opção viável.
+
 ## Contribuições
 Contribuições são bem-vindas! Por favor, faça um fork do repositório, crie um branch para sua funcionalidade e envie um pull request.
 

--- a/jupy_agenda/requirements.txt
+++ b/jupy_agenda/requirements.txt
@@ -6,6 +6,7 @@ Werkzeug>=3.0.0,<4.0.0
 SQLAlchemy==1.4.46 # Pinned due to a previous issue note, check if still needed or if latest is fine
 Flask-Mail>=0.10.0,<0.11.0
 gunicorn>=20.0.0,<23.0.0 # Added Gunicorn
+waitress>=2.1.0,<3.0.0 # For Windows production-like local server
 click>=8.0.0,<9.0.0 # For Flask CLI
 python-dotenv>=0.19.0,<1.2.0 # Good for managing .env files locally (optional but good practice)
 blinker>=1.6.0,<2.0.0 # Dependency of Flask/Signals


### PR DESCRIPTION
- Add `waitress` to requirements.txt as a WSGI server option.
- Update README.md to explain Gunicorn's limitations on Windows (fcntl module).
- Introduce Waitress as a Windows-compatible production-quality WSGI server.
- Provide clear instructions in Brazilian Portuguese for installing and running the application with Waitress on Windows, including environment variable considerations.